### PR TITLE
[OD-640] Remove _id column from datastore dump

### DIFF
--- a/ckanext/datastore/controller.py
+++ b/ckanext/datastore/controller.py
@@ -174,9 +174,13 @@ def dump_to(resource_id, output, fmt, offset, limit, options):
     except (ObjectNotFound, NotAuthorized):
         abort(404, _('Resource not found'))
 
+    # Get a list of field names, excluding "_id", to pass to result_page
     field_list = [f['id'] for f in rec['fields'] if f['id'] != '_id']
 
+    # Get the first set of records
     result = result_page(offset, limit, field_list)
+
+    # Get a list of dict with field names and type, excluding "_id"
     fields = [f for f in result['fields'] if f['id'] != '_id']
 
     with start_writer(fields) as wr:


### PR DESCRIPTION
[[OD-640](https://opengovinc.atlassian.net/browse/OD-640)] Remove _id column from datastore dump
## Description
This PR removes the column `_id` from the resource datastore dump file. The `_id` column would cause an error if users downloaded the file and uploaded it to CKAN again. The error is that the column `_id` is reserved in CKAN and should not be in a file.

Users also expect their data to be downloaded as is, without the presence of additional columns that CKAN adds.

## Test Procedure
Install and Setup
* Install CKAN 2.7.3
* Checkout this PR
* Restart CKAN

Create a datastore resource
* Create a datastore resource using the datastore API [datastore_create](http://docs.ckan.org/en/ckan-2.7.3/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_create)
* Add records to the datastore resource [datastore_upsert](http://docs.ckan.org/en/ckan-2.7.3/maintaining/datastore.html#ckanext.datastore.logic.action.datastore_upsert)

Download resource
* Go to the datastore resource and click on the download link
* The download link should be in the format `{ckan-site}/datastore/dump/{resource-id}`

## Approval Criteria
Download a datastore resource without the _id column.