### PR TITLE
Update data-fixed-columns to be false

### DIFF
--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -25,6 +25,7 @@
         data-col-reorder="false"
       {% endif %}
       data-fixed-header="true"
+      # This should be made configurable in the long-term
       data-fixed-columns="false"
       data-dom='"Blifrtip"'
       data-buttons='[

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -25,7 +25,7 @@
         data-col-reorder="false"
       {% endif %}
       data-fixed-header="true"
-      data-fixed-columns="true"
+      data-fixed-columns="false"
       data-dom='"Blifrtip"'
       data-buttons='[
         {

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -25,7 +25,7 @@
         data-col-reorder="false"
       {% endif %}
       data-fixed-header="true"
-      # This should be made configurable in the long-term
+      {# This should be made configurable in the long-term #} 
       data-fixed-columns="false"
       data-dom='"Blifrtip"'
       data-buttons='[


### PR DESCRIPTION
### Proposed fixes:
This disables data-fixed-columns by making it false. Having it be true causes headaches for customers where the view for the datatable appears misaligned when resizing a browser or modifying the amount of data displayed on the browswer.

We will make this attribute configurable in the future.

Test procedures:
- Download this branch and use it for your CKAN installation
- Go to a resource that has a datatable view or upload one that has several columns & add that view then resize the browser to verify the first column's position is not fixed and causing misalignment when viewing
- Use the resource that had column misalignment issues for Milwaukee to test if the columns get misaligned when resizing the browser: https://data.milwaukee.gov/dataset/votingward/resource/b50aed9e-2893-483c-a56a-3c51530c2cc9

### Features:

- [ ] includes tests covering changes
- [x] includes updated documentation
- [x] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
