### PR TITLE
[OD-832] Make Data Table fixed column extension configurable

### DIFF
--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -49,6 +49,7 @@ class DataTablesView(p.SingletonPlugin):
                 u'responsive': [default(False), boolean_validator],
                 u'export_buttons': [default(True), boolean_validator],
                 u'col_reorder': [default(False), boolean_validator],
+                u'fixed_columns': [default(False), boolean_validator],
                 u'show_fields': [ignore_missing],
                 u'filterable': [default(True), boolean_validator],
             }

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -14,13 +14,20 @@
   value='True',
   checked=data.export_buttons,
   ) }}
-  {{ form.checkbox(
-    'col_reorder',
-    id='field-col_reorder',
-    label=_('Column reorder'),
-    value='True',
-    checked=data.col_reorder,
-    ) }}
+{{ form.checkbox(
+  'col_reorder',
+  id='field-col_reorder',
+  label=_('Column reorder'),
+  value='True',
+  checked=data.col_reorder,
+  ) }}
+{{ form.checkbox(
+  'fixed_columns',
+  id='field-fixed_columns',
+  label=_('Fixed left column'),
+  value='True',
+  checked=data.fixed_columns,
+  ) }}
 
 <div class="control-group">
   <label class="control-label">{{ _('Show Columns') }}</label>

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -24,8 +24,12 @@
       {% else %}
         data-col-reorder="false"
       {% endif %}
+      {% if resource_view.get('fixed_columns') %}
+        data-fixed-columns="true"
+      {% else %}
+        data-fixed-columns="false"
+      {% endif %}
       data-fixed-header="true"
-      data-fixed-columns="true"
       data-dom='"Blifrtip"'
       data-buttons='[
         {


### PR DESCRIPTION
[[OD-832] Make Data Table fixed column extension configurable](https://opengovinc.atlassian.net/browse/OD-832)

## Description:
Currently the FixedColumns extension for DataTable view is set to be always enabled. FixedColumns provides the option to freeze a columns to the left of a horizontally scrolling DataTable. This is useful for long data rows.

However, the fixed column is actually a separate table from the original DataTable (i.e. they are separate table elements) which is styled to look like it's visually a part of the original table. This fixed table is then positioned over the original DataTable. This can cause a problem with the table heights becoming mismatched when resizing the browser.

Therefore FixedColumns should be configurable and disabled by default. Users can enable the option if desired.

## Test:
- Go to a tabular resource with data in the datastore
- Edit the resource and create a new Data Table view
  - Check if the first column is fixed (By default it should not)
- Edit the Data Table view and enable the fixed column option
  - Check that the first column is now fixed to the left side
- Ensure that the other options were not broken
  - Responsive display
  - Export buttons
  - Column reorder