### PR TITLE
Remove use of lazyjson

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -18,7 +18,7 @@ from cStringIO import StringIO
 import ckan.lib.cli as cli
 import ckan.plugins as p
 import ckan.plugins.toolkit as toolkit
-from ckan.lib.lazyjson import LazyJSONObject
+import simplejson as json
 
 import ckanext.datastore.helpers as datastore_helpers
 import ckanext.datastore.interfaces as interfaces
@@ -1301,7 +1301,7 @@ def search_data(context, data_dict):
         if v is None:
             records = []
         else:
-            records = LazyJSONObject(v)
+            records = json.loads(v)
     data_dict['records'] = records
 
     field_info = _get_field_info(


### PR DESCRIPTION
Intermittent LazyJSON errors when calling datastore_search. The error is LazyJSONObject is not JSON serializable.

### Features:
Replace lazyjson with simplejson.

### Testing Steps:
1) Go to the CKAN directory (.../src/ckan) and checkout this PR
2) Install and setup the odata extension https://github.com/opengov-opendata/ckanext-odata
3) Add the odata extension to the plugin list in the CKAN ini file. Make sure to place it before the datastore extension.
`ckan.plugins = ... odata datastore xloader ...`
4) Start CKAN and upload a tabular dataset
5) Query the resource using the datastore_search endpoint
`/api/action/datastore_search?resource_id=abcd1234-abcd-1234-abcd-1234abcd1234`
6) Query the resource using the datastore_search_sql endpoint
`/api/action/datastore_search_sql?sql=SELECT * from "abcd1234-abcd-1234-abcd-1234abcd1234" limit 10`
7) Query the resource using the odata endpoint
`/datastore/odata3.0/abcd1234-abcd-1234-abcd-1234abcd1234`

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
