### PR TITLE
[OD-765] Upgrade flask version in CKAN requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ Beaker==1.8.1 # Needs to be pinned to a more up to date version than the Pylons 
 bleach==1.5.0
 click==6.7
 fanstatic==0.12
-Flask==0.11.1
+Flask==0.12.4
 Jinja2==2.8
 Markdown==2.6.7
 ofs==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bleach==1.5.0
 click==6.7
 decorator==4.0.6          # via pylons, sqlalchemy-migrate
 fanstatic==0.12
-Flask==0.11.1
+Flask==0.12.4
 FormEncode==1.3.0         # via pylons
 funcsigs==1.0.2           # via beaker
 html5lib==0.9999999       # via bleach


### PR DESCRIPTION
[[OD-765] Upgrade flask version in CKAN requirements](https://opengovinc.atlassian.net/browse/OD-765)

## Description
We need to upgrade the version of Flask from 0.11.1 to 0.12.4 in CKAN 2.7.3's requirements. Flask versions before 0.12.3 contains an `Improper Input Validation` vulnerability that can result in a large amount of memory usage, potentially leading to denial of service. This attack appears to be exploitable when attackers provide JSON data in incorrect encodings. This vulnerability appears to have been fixed in 0.12.3.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
