### PR TITLE
[OD-996] Bumping SQLAlchemy to 0.9.8 from 0.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ rq==0.6.0
 simplejson==3.10.0
 six==1.10.0               # via bleach, html5lib, pastescript, pyutilib.component.core, sqlalchemy-migrate
 sqlalchemy-migrate==0.10.0
-SQLAlchemy==0.9.6         # via sqlalchemy-migrate
+SQLAlchemy==0.9.8         # via sqlalchemy-migrate
 sqlparse==0.2.2
 Tempita==0.5.2            # via pylons, sqlalchemy-migrate, weberror
 tzlocal==1.3


### PR DESCRIPTION
**Description:**

This PR updates SQLAlchemy to 0.9.8 from 0.9.6. Version 0.9.8 includes a bug patch that handles SSL SYCALL errors. This should enable CKAN to release stale connections to the DB after a restart of the DB instance.

"A revisit to this issue first patched in 0.9.5, apparently psycopg2’s .closed accessor is not as reliable as we assumed, so we have added an explicit check for the exception messages “SSL SYSCALL error: Bad file descriptor” and “SSL SYSCALL error: EOF detected” when detecting an is-disconnect scenario. We will continue to consult psycopg2’s connection.closed as a first check."

https://docs.sqlalchemy.org/en/latest/changelog/changelog_09.html#change-0.9.8-engine

Upgrading to this version however does result in the following warning appearing in ours logs:
```/usr/local/lib/python2.7/dist-packages/sqlalchemy/engine/default.py:585: SAWarning: Unicode type received non-unicodebind param value.```

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
