### PR TITLE
[ES-4149] Sort By option in Datatable View

### DIFF
--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -32,6 +32,15 @@ class DataTablesView(p.SingletonPlugin):
         return resource.get(u'datastore_active')
 
     def view_template(self, context, data_dict):
+        '''
+        Set the index of the sort column if it's displayed
+        '''
+        resource_view = data_dict.get('resource_view')
+        sort_column = resource_view.get('sort_column')
+        show_fields = resource_view.get('show_fields', [])
+        if sort_column in show_fields:
+            sort_index = show_fields.index(sort_column)
+            data_dict['resource_view']['sort_index'] = sort_index
         return u'datatables/datatables_view.html'
 
     def form_template(self, context, data_dict):

--- a/ckanext/datatablesview/plugin.py
+++ b/ckanext/datatablesview/plugin.py
@@ -51,6 +51,8 @@ class DataTablesView(p.SingletonPlugin):
                 u'col_reorder': [default(False), boolean_validator],
                 u'fixed_columns': [default(False), boolean_validator],
                 u'show_fields': [ignore_missing],
+                u'sort_column': [ignore_missing],
+                u'sort_order': [ignore_missing],
                 u'filterable': [default(True), boolean_validator],
             }
         }

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -70,5 +70,9 @@
         <option value="{{ order }}" {% if order == data.sort_order %} selected="selected" {% endif %}>{{ order }}</option>
       {% endfor %}
     </select>
+    <span class="info-block">
+      <i class="fa fa-info-circle"></i>
+      Sorting will only apply if sort column is visible (i.e. selected in the Show Columns table)
+    </span>
   </div>
 </div>

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -1,37 +1,32 @@
 {% import 'macros/form.html' as form %}
 
-{{ form.checkbox(
-  'responsive',
-  id='field-responsive',
-  label=_('Responsive display'),
-  value='True',
-  checked=data.responsive,
-  attrs={"title":"Optimize table layout for smaller screen sizes"},
-  ) }}
-{{ form.checkbox(
-  'export_buttons',
-  id='field-export_buttons',
-  label=_('Export buttons'),
-  value='True',
-  checked=data.export_buttons,
-  attrs={"title":"Add Copy and Print buttons"},
-  ) }}
-{{ form.checkbox(
-  'col_reorder',
-  id='field-col_reorder',
-  label=_('Column reorder'),
-  value='True',
-  checked=data.col_reorder,
-  attrs={"title":"Allow end users to reorder columns in a DataTable through a drag and drag operation"},
-  ) }}
-{{ form.checkbox(
-  'fixed_columns',
-  id='field-fixed_columns',
-  label=_('Fixed left column'),
-  value='True',
-  checked=data.fixed_columns,
-  attrs={"title":"Fix the left most column in place for use in x-axis scrolling"},
-  ) }}
+<div class="control-group">
+  <label class="control-label">Table Options</label>
+    <div class="controls">
+      <label class="checkbox" for="field-responsive" title="Optimize table layout for smaller screen sizes">
+        <input id="field-responsive" type="checkbox" name="responsive" value="True" {{ "checked " if data.responsive }}>
+        Enable responsive display
+      </label>
+    </div>
+    <div class="controls">
+      <label class="checkbox" for="field-export_buttons" title="Add Copy and Print buttons">
+        <input id="field-export_buttons" type="checkbox" name="export_buttons" value="True" {{ "checked " if data.export_buttons }}>
+        Display export buttons
+      </label>
+    </div>
+    <div class="controls">
+      <label class="checkbox" for="field-col_reorder" title="Allow users to reorder columns through a drag and drag operation">
+        <input id="field-col_reorder" type="checkbox" name="col_reorder" value="True" {{ "checked " if data.col_reorder }}>
+        Allow column reorder
+      </label>
+    </div>
+    <div class="controls">
+      <label class="checkbox" for="field-fixed_columns" title="Fix the _id column in place for use in x-axis scrolling">
+        <input id="field-fixed_columns" type="checkbox" name="fixed_columns" value="True" {{ "checked " if data.fixed_columns }}>
+        Fix _id column to left
+      </label>
+    </div>
+</div>
 
 <div class="control-group">
   <label class="control-label">{{ _('Show Columns') }}</label>
@@ -66,7 +61,7 @@
   <div class="controls">
     <select id="field-sort_column" name="sort_column">
       {% for f in [{'id': '_id'}] + h.datastore_dictionary(resource.id) %}
-        <option value="{{ loop.index0 }}" {% if loop.index0|string == data.sort_column|string %} selected="selected" {% endif %}>{{ f.id }}</option>
+        <option value="{{ f.id }}" {% if f.id|string == data.sort_column|string %} selected="selected" {% endif %}>{{ f.id }}</option>
       {% endfor %}
     </select>
     <select id="field-sort_order" name="sort_order">

--- a/ckanext/datatablesview/templates/datatables/datatables_form.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_form.html
@@ -6,6 +6,7 @@
   label=_('Responsive display'),
   value='True',
   checked=data.responsive,
+  attrs={"title":"Optimize table layout for smaller screen sizes"},
   ) }}
 {{ form.checkbox(
   'export_buttons',
@@ -13,6 +14,7 @@
   label=_('Export buttons'),
   value='True',
   checked=data.export_buttons,
+  attrs={"title":"Add Copy and Print buttons"},
   ) }}
 {{ form.checkbox(
   'col_reorder',
@@ -20,6 +22,7 @@
   label=_('Column reorder'),
   value='True',
   checked=data.col_reorder,
+  attrs={"title":"Allow end users to reorder columns in a DataTable through a drag and drag operation"},
   ) }}
 {{ form.checkbox(
   'fixed_columns',
@@ -27,6 +30,7 @@
   label=_('Fixed left column'),
   value='True',
   checked=data.fixed_columns,
+  attrs={"title":"Fix the left most column in place for use in x-axis scrolling"},
   ) }}
 
 <div class="control-group">
@@ -54,5 +58,22 @@
         </tr>
       {% endfor %}
     </table>
+  </div>
+</div>
+
+<div class="control-group control-select">
+  <label class="control-label" for="field-sort_column">{{ _('Sort By') }}</label>
+  <div class="controls">
+    <select id="field-sort_column" name="sort_column">
+      {% for f in [{'id': '_id'}] + h.datastore_dictionary(resource.id) %}
+        <option value="{{ loop.index0 }}" {% if loop.index0|string == data.sort_column|string %} selected="selected" {% endif %}>{{ f.id }}</option>
+      {% endfor %}
+    </select>
+    <select id="field-sort_order" name="sort_order">
+      {% set order_list = ['asc','desc'] %}
+      {% for order in order_list %}
+        <option value="{{ order }}" {% if order == data.sort_order %} selected="selected" {% endif %}>{{ order }}</option>
+      {% endfor %}
+    </select>
   </div>
 </div>

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -32,10 +32,10 @@
       {% else %}
         data-fixed-columns="false"
       {% endif %}
-      {% set sort_column = resource_view.get('sort_column') %}
+      {% set sort_index = resource_view.get('sort_index') %}
       {% set sort_order = resource_view.get('sort_order') %}
-      {% if sort_column %}
-        data-order='[ [ {{ sort_column }}, "{{sort_order}}" ], [ 0, "{{sort_order}}" ] ]'
+      {% if sort_index and sort_order %}
+        data-order='[ [ {{ sort_index }}, "{{sort_order}}" ] ]'
       {% endif %}
       data-fixed-header="true"
       data-dom='"Blifrtip"'

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -34,7 +34,7 @@
       {% endif %}
       {% set sort_index = resource_view.get('sort_index') %}
       {% set sort_order = resource_view.get('sort_order') %}
-      {% if sort_index and sort_order %}
+      {% if sort_index >= 0 and sort_order %}
         data-order='[ [ {{ sort_index }}, "{{sort_order}}" ] ]'
       {% endif %}
       data-fixed-header="true"

--- a/ckanext/datatablesview/templates/datatables/datatables_view.html
+++ b/ckanext/datatablesview/templates/datatables/datatables_view.html
@@ -32,6 +32,11 @@
       {% else %}
         data-fixed-columns="false"
       {% endif %}
+      {% set sort_column = resource_view.get('sort_column') %}
+      {% set sort_order = resource_view.get('sort_order') %}
+      {% if sort_column %}
+        data-order='[ [ {{ sort_column }}, "{{sort_order}}" ], [ 0, "{{sort_order}}" ] ]'
+      {% endif %}
       data-fixed-header="true"
       data-dom='"Blifrtip"'
       data-buttons='[


### PR DESCRIPTION
## [TICKET](https://opengovinc.atlassian.net/browse/ES-4149)

## Description
<!--- Describe these changes in detail --->
This PR adds a new option to the Datatable resource view to sort the table by a specific column in ascending or descending order. 

## Testing
1) Checkout this CKAN branch
```
git fetch --all
git checkout jguo144/ES-4149/2019-03-28/add-sort-by-option-to-datatable
```

2) Make sure that Datatables view is installed in the ini file
`ckan.plugins = stats ... datatables_view ...`

3) Test existing Datatable view
    - Go to an existing resource with a Datatable view
    - Verify that the existing Datatable view is not broken and is sorted by the **_id** field
    - Edit the Datatable view and select another column to sort the table by.
    - Verify that the Datatable view is sorted based on the selected column.

4) Test new Datatable view
    - Create a new resurce and upload a new CSV file
    - Verify that the newly created Datatable view is sorted by the **_id** field
    - Edit the Datatable view and select another column to sort the table by.
    - Verify that the Datatable view is sorted based on the selected column.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
