### PR TITLE
[ESN-137] Add _id as default sort column

### DIFF
--- a/ckanext/datatablesview/controller.py
+++ b/ckanext/datatablesview/controller.py
@@ -44,6 +44,9 @@ class DataTablesController(BaseController):
             sort_list.append(cols[sort_by_num] + u' ' + sort_order)
             i += 1
 
+        if u'_id asc' not in sort_list and u'_id desc' not in sort_list:
+            sort_list.append(u'_id asc')
+
         response = datastore_search(None, {
             u"q": search_text,
             u"resource_id": resource_view[u'resource_id'],


### PR DESCRIPTION
## [ESN-137](https://opengovinc.atlassian.net/browse/ESN-137)

## Description
<!--- Describe these changes in detail --->
When users sort columns the _id column should be added to make it sort in a unique order. This will prevent rows from appearing multiple times when paginating results with a non-unique order.

## Testing
- Download the file from https://data.pompanobeachfl.gov/dataset/voter-statistics/resource/9da063be-3b0b-4d43-8cbf-acedb0730a57
- Upload the file to your local environment and upload it to the datastore
- In the datatable view sort the Precinct column and check that the row with `_id` 1 appears on multiple pages.
![screenshot-1](https://user-images.githubusercontent.com/4096633/64648154-5b59dc80-d3e8-11e9-8ad0-f460220ebaa3.png)
- Checkout this PR and restart CKAN
- Go to the resource, sort the Precinct column, and check that there are no repeating rows on different pages

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
