### PR TITLE
[PERF-816] Update datastore_search to use write_url_search db connection

### DIFF
--- a/ckanext/datastore/backend/postgres.py
+++ b/ckanext/datastore/backend/postgres.py
@@ -1496,7 +1496,7 @@ def upsert(context, data_dict):
 
 def search(context, data_dict):
     backend = DatastorePostgresqlBackend.get_active_backend()
-    engine = backend._get_write_engine()
+    engine = backend._get_write_search_engine()
     context['connection'] = engine.connect()
     timeout = context.get('query_timeout', _TIMEOUT)
     _cache_types(context['connection'])
@@ -1590,6 +1590,9 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
     def _get_write_engine(self):
         return _get_engine_from_url(self.write_url)
+
+    def _get_write_search_engine(self):
+        return _get_engine_from_url(self.write_url_search)
 
     def _get_read_engine(self):
         return _get_engine_from_url(self.read_url)
@@ -1707,8 +1710,11 @@ class DatastorePostgresqlBackend(DatastoreBackend):
 
         self.ckan_url = self.config['sqlalchemy.url']
         self.write_url = self.config['ckan.datastore.write_url']
-        self.write_url_search = self.config.get('ckan.datastore.write_url_search') \
-                                or self.config['ckan.datastore.write_url']
+
+        if self.config.get('ckan.datastore.write_url_search'):
+            self.write_url_search = self.config.get('ckan.datastore.write_url_search')
+        else:
+            self.write_url_search = self.config['ckan.datastore.write_url']
 
         self.legacy_mode = self.is_legacy_mode(config)
 


### PR DESCRIPTION
## [PERF-816](https://opengovinc.atlassian.net/browse/PERF-816)

The datastore_search currently uses the write_url db connection due to permissioning. The search endpoint needs the ckan_default user to access resources in private datasets. As a workaround we added the `write_url_search` db connection, which is a user with owner role connecting to read replica.

Note that this issue is fixed in later versions of CKAN. Instead of denying all sql on private datasets, the resource_show auth method is called for each table the user is accessing. The query is refused when any of those checks fail. The PR that fixed this was https://github.com/ckan/ckan/pull/2562


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
