### PR TITLE
Update psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PasteDeploy==1.5.2        # via pastescript, pylons
 PasteScript==2.0.2        # via pylons
 pbr==1.10.0               # via sqlalchemy-migrate
 polib==1.0.7
-psycopg2==2.4.5
+psycopg2==2.7.3.2
 Pygments==2.1.3           # via weberror
 Pylons==0.9.7
 pysolr==3.6.0


### PR DESCRIPTION
## Description
This PR updates the version of psycopg2 in the requirements file to `2.7.3.2`.
According to the CKAN changelog there's a bug in the psycopg2 version pinned to the CKAN 2.7 release.
You can read more in the CKAN 2.7 [changelog](https://docs.ckan.org/en/2.7/changelog.html#v2-7-3-2018-03-15).


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
