### PR TITLE
Revert "Update psycopg2 version"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ PasteDeploy==1.5.2        # via pastescript, pylons
 PasteScript==2.0.2        # via pylons
 pbr==1.10.0               # via sqlalchemy-migrate
 polib==1.0.7
-psycopg2==2.7.3.2
+psycopg2==2.4.5
 Pygments==2.1.3           # via weberror
 Pylons==0.9.7
 pysolr==3.6.0


### PR DESCRIPTION
## Description
This PR reverts OpenGov-OpenData/ckan#26.
The version of psycopg2 was updated from `2.4.5` to `2.7.3.2` as suggested in the CKAN changelog as a workaround for issues that occur in our vagrant script. https://docs.ckan.org/en/2.7/changelog.html#v2-7-3-2018-03-15

However, the update causes a TypeError when the datastore SQL api is used.
The error occurs on this line https://github.com/ckan/ckan/blob/2.7/ckanext/datastore/helpers.py#L108.
Here result['QUERY PLAN'] is expected to be a string and psycopg2 `2.4.5` will return a string. Newer versions of psycopg2 will return a list instead.