### PR TITLE
Remove link to Google+ from CNRA branch

### DIFF
--- a/ckan/templates/snippets/social.html
+++ b/ckan/templates/snippets/social.html
@@ -6,7 +6,6 @@
     {% endblock %}
     {% block social_nav %}
       <ul class="nav nav-simple">
-        <li class="nav-item"><a href="https://plus.google.com/share?url={{ current_url }}" target="_blank"><i class="fa fa-google-plus-square"></i> Google+</a></li>
         <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fa fa-twitter-square"></i> Twitter</a></li>
         <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fa fa-facebook-square"></i> Facebook</a></li>
       </ul>


### PR DESCRIPTION
### Proposed fixes:
Remove link to Google+ from `release-v2.7.3-cnra`


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
