### PR TITLE
Add more template blocks to data dictionary

### DIFF
--- a/ckanext/datastore/templates/package/resource_read.html
+++ b/ckanext/datastore/templates/package/resource_read.html
@@ -9,7 +9,7 @@
 
 {% block resource_additional_information_inner %}
   {% if res.datastore_active %}
-    {% set ddict=h.datastore_dictionary(res.id) %}
+  {% block resource_data_dictionary %}
     <div class="module-content">
       <h2>
         {{ _('Data Dictionary') }}
@@ -17,24 +17,30 @@
       </h2>
       <table class="table table-striped table-bordered table-condensed" data-module="table-toggle-more">
         <thead>
+          {% block resouce_data_dictionary_headers %}
           <tr>
             <th scope="col">{{ _('Column') }}</th>
             <th scope="col">{{ _('Type') }}</th>
             <th scope="col">{{ _('Label') }}</th>
             <th scope="col">{{ _('Description') }}</th>
           </tr>
+          {% endblock %}
         </thead>
-        {% for f in ddict %}
-          <tr {% if loop.index > 5 %}class="toggle-more"{% endif %}>
-            <td>{{ f.id }}</td>
-            <td>{{ f.type }}</td>
-            <td>{{ h.get_translated(f.get('info', {}), 'label') }}</td>
-            <td>{{ h.render_markdown(
-              h.get_translated(f.get('info', {}), 'notes')) }}</td>
-          </tr>
-        {% endfor %}
+        {% block resource_data_dictionary_data %}
+          {% set dict=h.datastore_dictionary(res.id) %}
+          {% for field in dict %}
+            <tr {% if loop.index > 5 %}class="toggle-more"{% endif %}>
+              <td>{{ field.id }}</td>
+              <td>{{ field.type }}</td>
+              <td>{{ h.get_translated(field.get('info', {}), 'label') }}</td>
+              <td>{{ h.render_markdown(
+                h.get_translated(field.get('info', {}), 'notes')) }}</td>
+            </tr>
+          {% endfor %}
+        {% endblock %}
       </table>
     </div>
+  {% endblock %}
   {% endif %}
   {{ super() }}
 {% endblock %}


### PR DESCRIPTION
Fixes #

### Proposed fixes:
This PR backports some template blocks for the data dictionary in `resource_read.html` to CKAN 2.7

Changes are from the datastore `resource_read.html` template in CKAN 2.9
https://github.com/ckan/ckan/blob/2.9/ckanext/datastore/templates/package/resource_read.html

Extensions like ckanext-scheming are already extending these blocks as seen [here](https://github.com/ckan/ckanext-scheming/blob/90ed8dbec0b805eaf6071f43eeb86b748bc0296d/ckanext/scheming/templates/scheming/package/resource_read.html#L13-L15)
The parent blocks is needed for `resource_read` to be rendered correctly when the scheming extension is enabled.

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
