### PR TITLE
Add Cast to allowed Datastore functions

### DIFF
--- a/ckanext/datastore/allowed_functions.txt
+++ b/ckanext/datastore/allowed_functions.txt
@@ -41,6 +41,7 @@ box
 broadcast
 btrim
 cardinality
+cast
 cbrt
 ceil
 ceiling


### PR DESCRIPTION
Fixes #

### Proposed fixes:
Add cast() to allowed Datastore functions in CKAN 2.7


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
