### PR TITLE
Use custom config to set limit for group/org index

### DIFF
--- a/ckan/controllers/group.py
+++ b/ckan/controllers/group.py
@@ -150,7 +150,7 @@ class GroupController(base.BaseController):
         group_type = self._guess_group_type()
 
         page = h.get_page_number(request.params) or 1
-        items_per_page = 21
+        items_per_page = int(config.get('ckan.datasets_per_page', 20))
 
         context = {'model': model, 'session': model.Session,
                    'user': c.user, 'for_view': True,


### PR DESCRIPTION
## Description
Use custom config `ckan.datasets_per_page` to set the limit for group/org index when paginating results.


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
