### PR TITLE
Tighten checks around incoming resource ids

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -243,13 +243,19 @@ class ResourceUpload(object):
             resource['url_type'] = ''
 
     def get_directory(self, id):
-        directory = os.path.join(self.storage_path,
-                                 id[0:3], id[3:6])
+        real_storage = os.path.realpath(self.storage_path)
+        directory = os.path.join(real_storage, id[0:3], id[3:6])
+        if directory != os.path.realpath(directory):
+            raise logic.ValidationError({'upload': ['Invalid storage directory']})
         return directory
 
     def get_path(self, id):
         directory = self.get_directory(id)
         filepath = os.path.join(directory, id[6:])
+
+        if filepath != os.path.realpath(filepath):
+            raise logic.ValidationError({'upload': ['Invalid storage path']})
+
         return filepath
 
     def upload(self, id, max_size=10):

--- a/ckan/logic/schema.py
+++ b/ckan/logic/schema.py
@@ -75,12 +75,15 @@ from ckan.logic.validators import (
     package_id_does_not_exist,
     email_validator,
     extras_valid_json,
+    resource_id_validator,
+    resource_id_does_not_exist,
     )
 
 
 def default_resource_schema():
     schema = {
-        'id': [ignore_empty, unicode],
+        'id': [ignore_empty, resource_id_validator,
+               resource_id_does_not_exist, unicode],
         'revision_id': [ignore_missing, unicode],
         'package_id': [ignore],
         'url': [ignore_missing, unicode, remove_whitespace],

--- a/ckan/logic/validators.py
+++ b/ckan/logic/validators.py
@@ -8,6 +8,8 @@ import mimetypes
 import json
 import urlparse
 
+from sqlalchemy.orm.exc import NoResultFound
+
 import ckan.lib.navl.dictization_functions as df
 import ckan.logic as logic
 import ckan.lib.helpers as h
@@ -161,6 +163,29 @@ def package_id_does_not_exist(value, context):
         raise Invalid(_('Dataset id already exists'))
     return value
 
+
+def resource_id_does_not_exist(key, data, errors, context):
+    session = context['session']
+    model = context['model']
+
+    if data[key] is missing:
+        return
+    resource_id = data[key]
+    assert key[0] == 'resources', ('validator depends on resource schema '
+                                   'validating as part of package schema')
+    package_id = data.get(('id',))
+    query = session.query(model.Resource.package_id).filter(
+        model.Resource.id == resource_id,
+        model.Resource.state != State.DELETED,
+    )
+    try:
+        [parent_id] = query.one()
+    except NoResultFound:
+        return
+    if parent_id != package_id:
+        errors[key].append(_('Resource id already exists.'))
+
+
 def package_name_exists(value, context):
 
     model = context['model']
@@ -200,6 +225,15 @@ def resource_id_exists(value, context):
     session = context['session']
     if not session.query(model.Resource).get(value):
         raise Invalid('%s: %s' % (_('Not found'), _('Resource')))
+    return value
+
+
+def resource_id_validator(value):
+    pattern = re.compile("[^0-9a-zA-Z _-]")
+    if pattern.search(value):
+        raise Invalid(_('Invalid characters in resource id'))
+    if len(value) < 7 or len(value) > 100:
+        raise Invalid(_('Invalid length for resource id'))
     return value
 
 

--- a/ckan/tests/logic/action/test_create.py
+++ b/ckan/tests/logic/action/test_create.py
@@ -450,6 +450,42 @@ class TestResourceCreate(object):
         assert_raises(logic.ValidationError, helpers.call_action,
                       'resource_create', **data_dict)
 
+    def test_invalid_characters_in_id(self):
+
+        data_dict = {
+            "id": "../../nope.txt",
+            "package_id": factories.Dataset()["id"],
+            "url": "http://data",
+            "name": "A nice resource",
+        }
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+                      'resource_create', **data_dict)
+
+    def test_id_too_long(self):
+
+        data_dict = {
+            "id": "x" * 111,
+            "package_id": factories.Dataset()["id"],
+            "url": "http://data",
+            "name": "A nice resource",
+        }
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+                      'resource_create', **data_dict)
+
+    def test_id_already_exists(self):
+        data_dict = {
+            'id': 'wont-be-fooled-again',
+            'package_id': factories.Dataset()['id'],
+        }
+        helpers.call_action('resource_create', **data_dict)
+
+        data_dict['package_id'] = factories.Dataset()['id']
+
+        assert_raises(logic.ValidationError, helpers.call_action,
+                      'resource_create', **data_dict)
+
     def test_doesnt_require_url(self):
         user = factories.User()
         dataset = factories.Dataset(user=user)

--- a/ckan/tests/logic/action/test_patch.py
+++ b/ckan/tests/logic/action/test_patch.py
@@ -8,6 +8,7 @@ import mock
 from ckan.common import config
 
 from ckan.tests import helpers, factories
+from ckan.logic import ValidationError
 
 
 class TestPatch(helpers.FunctionalTestBase):
@@ -31,6 +32,24 @@ class TestPatch(helpers.FunctionalTestBase):
 
         assert_equals(dataset2['name'], 'somethingnew')
         assert_equals(dataset2['notes'], 'some test now')
+
+    def test_package_patch_invalid_characters_in_resource_id(self):
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        data_dict = {
+            'id': dataset["id"],
+            'resources': [
+                {
+                    "id": "../../nope.txt",
+                    "url": "http://data",
+                    "name": "A nice resource",
+                },
+            ]
+        }
+
+        assert_raises(ValidationError,
+                      helpers.call_action,
+                      'package_patch', **data_dict)
 
     def test_resource_patch_updating_single_field(self):
         user = factories.User()

--- a/ckan/tests/logic/action/test_update.py
+++ b/ckan/tests/logic/action/test_update.py
@@ -650,6 +650,24 @@ class TestDatasetUpdate(helpers.FunctionalTestBase):
         assert_equals(resources_[1]['url'], 'http://datahub.io/index.json')
         assert_equals(resources_[1]['position'], 1)
 
+    def test_invalid_characters_in_resource_id(self):
+        user = factories.User()
+        dataset = factories.Dataset(user=user)
+        data_dict = {
+            'id': dataset["id"],
+            'resources': [
+                {
+                    "id": "../../nope.txt",
+                    "url": "http://data",
+                    "name": "A nice resource",
+                },
+            ]
+        }
+
+        assert_raises(logic.ValidationError,
+                      helpers.call_action,
+                      'package_update', **data_dict)
+
     def test_tags(self):
         user = factories.User()
         dataset = factories.Dataset(


### PR DESCRIPTION
Fixes [CVE-2023-32321](https://github.com/ckan/ckan/security/advisories/GHSA-446m-hmmm-hm8m)

### Impact
A user with permissions to create or edit a dataset can upload a resource with a specially crafted id to write the uploaded file in an arbitrary location.

### Proposed fixes:
This PR backports the vulnerability patch from CKAN 2.9.9 (https://github.com/ckan/ckan/commit/d7d1801cbe26c6099f73a2fa403be547143d082f)

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
