### PR TITLE
Sqlalchemy 1.3 only accepts 0 and 1 as boolean values

### DIFF
--- a/ckan/views/user.py
+++ b/ckan/views/user.py
@@ -280,7 +280,9 @@ class EditView(MethodView):
 
         except dictization_functions.DataError:
             base.abort(400, _(u'Integrity Error'))
-        data_dict.setdefault(u'activity_streams_email_notifications', False)
+        data_dict.setdefault(u'activity_streams_email_notifications', 0)
+        if data_dict.get(u'activity_streams_email_notifications'):
+            data_dict[u'activity_streams_email_notifications'] = 1
 
         context[u'message'] = data_dict.get(u'log_message', u'')
         data_dict[u'id'] = id


### PR DESCRIPTION
## Description
This PR fixes an issue when trying to set the `Subscribe to notification emails` checkbox option to True in the user edit form. The raised exception is
```
sqlalchemy.exc.StatementError: (builtins.TypeError) Not a boolean value: 'True'
[SQL: UPDATE "user" SET about=%(about)s, activity_streams_email_notifications=%(activity_streams_email_notifications)s WHERE "user".id = %(user_id)s]
```

The issue is that sqlalchemy after 1.2 only accepts the integer values 0 and 1 as True and False boolean values. Values other than the 0 and 1 integers will raise an exception.

For more information:
https://docs.sqlalchemy.org/en/13/changelog/migration_12.html#change-4102


### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
