### PR TITLE
Fix reset_key generation

### DIFF
--- a/ckan/lib/mailer.py
+++ b/ckan/lib/mailer.py
@@ -203,12 +203,12 @@ def send_invite(user, group_dict=None, role=None):
 
 
 def create_reset_key(user):
-    user.reset_key = text_type(make_key())
+    user.reset_key = make_key()
     model.repo.commit()
 
 
 def make_key():
-    return codecs.encode(os.urandom(16), 'hex')
+    return codecs.encode(os.urandom(16), 'hex').decode()
 
 
 def verify_reset_link(user, key):


### PR DESCRIPTION
# Description
The reset_key was being stored as the string representation of a bytes string, which caused the password reset link in emails to lead to a 404 page. Instead it should be stored as a plain string.